### PR TITLE
devdraw: Fix mouse wheel scrolling in 1-tick increments on macOS

### DIFF
--- a/src/cmd/devdraw/mac-screen.m
+++ b/src/cmd/devdraw/mac-screen.m
@@ -601,12 +601,12 @@ rpc_resizewindow(Client *c, Rectangle r)
 
 - (void)scrollWheel:(NSEvent*)e
 {
-	NSInteger s;
+	CGFloat s;
 
 	s = [e scrollingDeltaY];
-	if(s > 0)
+	if(s > 0.0f)
 		[self sendmouse:8];
-	else if (s < 0)
+	else if (s < 0.0f)
 		[self sendmouse:16];
 }
 


### PR DESCRIPTION
Fix an issue with mouse wheel scrolling where float delta values were getting truncated into an integer, resulting in slow single-tick wheel scrolls being ignored